### PR TITLE
Feature/replace prng

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ doc/api/
 .flutter-plugins-dependencies
 .idea
 unicode_data/UnicodeData.txt
+xorshift.py
+xorshift.c
+*.out

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## develop
+
+- [CHANGE] Replace the PRNG with new implemented PRNG which enables to reproduce random values using internal state
+- [CHANGE] Remove the dependency on package:mt19937
+
 ## 1.1.0
 
 - [ADD] Support Web platform

--- a/lib/src/random.dart
+++ b/lib/src/random.dart
@@ -1,8 +1,7 @@
 import 'dart:math' as math;
 import 'dart:math';
 
-import 'package:kiri_check/src/constants.dart';
-import 'package:mt19937/mt19937.dart';
+import 'package:kiri_check/src/random_xorshift.dart';
 
 abstract class RandomContext implements Random {
   int? get seed;
@@ -31,36 +30,26 @@ abstract class RandomContext implements Random {
 
 final class RandomContextImpl extends RandomContext {
   RandomContextImpl([this.seed]) {
-    mt = RandomMt19937(seed: seed);
-    mt64 = RandomMt19937_64(seed: seed);
+    xorshift = RandomXorshift(seed);
   }
 
   @override
   final int? seed;
 
-  late final RandomMt19937 mt;
-  late final RandomMt19937_64 mt64;
+  late final RandomXorshift xorshift;
 
   @override
-  int nextInt(int max) {
-    if (max <= 0) {
-      throw ArgumentError('max must be greater than or equal to 0: $max');
-    } else if (max <= Constants.int32Max) {
-      return mt.nextInt(max);
-    } else {
-      return mt64.nextInt(max);
-    }
-  }
+  int nextInt(int max) => xorshift.nextInt(max);
 
   @override
-  double nextDouble() => mt64.nextDouble();
+  double nextDouble() => xorshift.nextDouble();
 
   @override
-  bool nextBool() => mt.nextBool();
+  bool nextBool() => xorshift.nextBool();
 
   @override
   Element nextElement<Element>(List<Element> elements) {
-    return elements[mt.nextInt(elements.length)];
+    return elements[xorshift.nextInt(elements.length)];
   }
 }
 

--- a/lib/src/random_new.dart
+++ b/lib/src/random_new.dart
@@ -1,0 +1,70 @@
+// xorshift32
+
+import 'dart:math';
+
+import 'package:universal_platform/universal_platform.dart';
+
+final class RandomState {
+  RandomState([this.seed]) {
+    if (seed != null) {
+      if (seed == 0) {
+        throw ArgumentError('seed must be non-zero');
+      }
+      RangeError.checkValueInInterval(seed!, 0, 0x7FFFFFFF);
+    }
+  }
+
+  factory RandomState.fromState(RandomState state) {
+    return RandomState(state.seed);
+  }
+
+  // TODO: 他にいい値はある？
+  static const int defaultSeed = 88675123;
+
+  int? seed;
+  int x = 123456789;
+}
+
+final class NewRandom implements Random {
+  NewRandom([int? seed]) {
+    state = RandomState(seed);
+    if (seed != null) {
+      state.x = seed;
+    }
+  }
+
+  factory NewRandom.fromState(RandomState state) => NewRandom()..state = state;
+
+  RandomState state = RandomState();
+
+  int nextInt32() {
+    var x = state.x;
+    x ^= x << 13;
+    x ^= x >> 17;
+    x ^= x << 5;
+    state.x = x;
+    return x;
+  }
+
+  @override
+  bool nextBool() {
+    return nextInt32() & 1 == 1;
+  }
+
+  @override
+  double nextDouble() {
+    // TODO
+    return nextInt32() / 0x7FFFFFFF;
+  }
+
+  @override
+  int nextInt(int max) {
+    var value = nextInt32();
+    if (UniversalPlatform.isWeb) {
+      return nextInt32() % max;
+    } else {
+      value = value << 32 | nextInt32();
+      return value % max;
+    }
+  }
+}

--- a/lib/src/random_xorshift.dart
+++ b/lib/src/random_xorshift.dart
@@ -1,7 +1,6 @@
 import 'dart:math';
 
 import 'package:kiri_check/src/constants.dart';
-import 'package:universal_platform/universal_platform.dart';
 
 // xorshift32
 final class RandomState {

--- a/lib/src/random_xorshift.dart
+++ b/lib/src/random_xorshift.dart
@@ -59,6 +59,9 @@ final class RandomXorshift implements Random {
 
   @override
   int nextInt(int max) {
+    if (max <= 0) {
+      throw ArgumentError('max must be greater than or equal to 0: $max');
+    }
     var value = nextInt32();
     if (value > Constants.safeIntMax) {
       value = value << 32 | nextInt32();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,6 @@ dependencies:
   collection: ^1.19.0
   date_kit: ^1.0.2
   meta: ^1.15.0
-  mt19937: ^0.1.0
   test: ^1.25.7
   timezone: ^0.9.3
   universal_platform: ^1.1.0

--- a/test/random_test.dart
+++ b/test/random_test.dart
@@ -93,7 +93,8 @@ void main() {
 
   group('default random', () {
     test('bool', () {
-      final random = RandomContextImpl(DateTime.now().microsecondsSinceEpoch);
+      final random =
+          RandomContextImpl(DateTime.now().microsecondsSinceEpoch & 0x7FFFFFFF);
       const n = 1000;
       var trues = 0;
       for (var i = 0; i < n; i++) {
@@ -106,7 +107,8 @@ void main() {
 
     group('int', () {
       test('equality', () {
-        final random = RandomContextImpl(DateTime.now().microsecondsSinceEpoch);
+        final random = RandomContextImpl(
+            DateTime.now().microsecondsSinceEpoch & 0x7FFFFFFF);
         var lt100 = 0;
         var lt200 = 0;
         var lt300 = 0;
@@ -155,7 +157,8 @@ void main() {
       });
 
       test('edge cases (0, max)', () {
-        final random = RandomContextImpl(DateTime.now().microsecondsSinceEpoch);
+        final random = RandomContextImpl(
+            DateTime.now().microsecondsSinceEpoch & 0x7FFFFFFF);
         const max = 100;
         var hasZero = false;
         var hasMax = false;

--- a/test/random_test.dart
+++ b/test/random_test.dart
@@ -4,9 +4,93 @@
 // seed
 
 import 'package:kiri_check/src/random.dart';
+import 'package:kiri_check/src/random_xorshift.dart';
 import 'package:test/test.dart';
 
 void main() {
+  group('xorshift', () {
+    test('basic', () {
+      const seed = 1234567;
+      final random = RandomXorshift(seed);
+      expect(random.state.seed, seed, reason: 'seed');
+
+      final expected = [
+        42034982,
+        3805524628,
+        78537300,
+        3564389094,
+        3644666546,
+        2449665511,
+        947072312,
+        3881073042,
+        1688713601,
+        3782072586,
+      ];
+      for (var i = 0; i < expected.length; i++) {
+        expect(random.nextInt32(), expected[i], reason: 'count $i');
+      }
+    });
+
+    group('seed', () {
+      test('seed 0', () {
+        expect(() => RandomXorshift(0), throwsArgumentError);
+      });
+
+      test('fix seed', () {
+        const seed = 1234567;
+        final r1 = RandomXorshift(seed);
+        final r2 = RandomXorshift(seed);
+        for (var i = 0; i < 100; i++) {
+          expect(r1.nextInt32(), r2.nextInt32());
+        }
+      });
+
+      test('different seed', () {
+        const seed1 = 1234567;
+        const seed2 = 7654321;
+        final r1 = RandomXorshift(seed1);
+        final r2 = RandomXorshift(seed2);
+        var same = 0;
+        for (var i = 0; i < 1000; i++) {
+          if (r1.nextInt32() == r2.nextInt32()) {
+            same++;
+          }
+        }
+        expect(same, lessThan(10));
+      });
+    });
+
+    group('random state', () {
+      test('copy state', () {
+        final r1 = RandomXorshift()..nextInt32();
+        final r2 = RandomXorshift.fromState(r1.state);
+        expect(r2.state.seed, r1.state.seed, reason: 'seed');
+        expect(r2.state.x, r1.state.x, reason: 'x');
+
+        for (var i = 0; i < 100; i++) {
+          expect(r2.nextInt32(), r1.nextInt32());
+          expect(r2.state.x, r1.state.x);
+        }
+      });
+
+      test('rollback state', () {
+        final r1 = RandomXorshift();
+        final s1 = RandomState.fromState(r1.state);
+        final values = <int>[];
+        for (var i = 0; i < 100; i++) {
+          values.add(r1.nextInt32());
+        }
+
+        r1.state = s1;
+        for (var i = 0; i < 100; i++) {
+          expect(r1.nextInt32(), values[i]);
+        }
+      });
+    });
+
+    // TODO: bool, int, double
+  });
+
   group('default random', () {
     test('bool', () {
       final random = RandomContextImpl(DateTime.now().microsecondsSinceEpoch);


### PR DESCRIPTION
Replace the current PRNG (MT) with a new PRNG (xorshift).

- Add a new PRNG implementation
- Remove the dependency on the package:mt19937

Here are the reasons for these changes:

- To improve performance
- In this testing library, I determined that the precision of random numbers provided by xorshift is sufficient
- To prepare a PRNG implementation that enables the reproduction of random values using an internal state, which will be useful for future refactoring of the cache mechanism
- To reduce dependencies on other libraries
