### PR TITLE
Add `build` arbitrary that accepts callable objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [CHANGE] Support asynchronous for stateless testing
 - [CHANGE] Support asynchronous for stateful testing
 - [CHANGE] Enable random value generation using arbitraries outside of tests (#18)
+- [CHANGE] Add `build` arbitrary that accepts callable objects (#20)
 - [UPDATE] Show the exception and stack trace of falsifying examples
 
 ### API

--- a/lib/kiri_check.dart
+++ b/lib/kiri_check.dart
@@ -4,6 +4,7 @@ export 'src/arbitrary/top.dart'
     show
         binary,
         boolean,
+        build,
         combine2,
         combine3,
         combine4,

--- a/lib/src/arbitrary/combinator/build.dart
+++ b/lib/src/arbitrary/combinator/build.dart
@@ -1,0 +1,42 @@
+import 'package:kiri_check/src/arbitrary.dart';
+import 'package:kiri_check/src/exception.dart';
+import 'package:kiri_check/src/random.dart';
+
+abstract class BuildArbitraries {
+  static Arbitrary<T> build<T>(T Function() builder) => BuildArbitrary(builder);
+}
+
+final class BuildArbitrary<T> extends ArbitraryBase<T> {
+  BuildArbitrary(this._builder);
+
+  final T Function() _builder;
+
+  @override
+  int get enumerableCount => 0;
+
+  @override
+  List<T>? get edgeCases => null;
+
+  @override
+  bool get isExhaustive => false;
+
+  @override
+  T getFirst(RandomContext random) => _builder();
+
+  @override
+  T generate(RandomContext random) => _builder();
+
+  @override
+  T generateRandom(RandomContext random) => _builder();
+
+  @override
+  List<T> generateExhaustive() => throw PropertyException(
+        'build arbitrary does not support exhaustive generation',
+      );
+
+  @override
+  ShrinkingDistance calculateDistance(T value) => ShrinkingDistance(0);
+
+  @override
+  List<T> shrink(T value, ShrinkingDistance distance) => [];
+}

--- a/lib/src/arbitrary/top.dart
+++ b/lib/src/arbitrary/top.dart
@@ -1,4 +1,5 @@
 import 'package:kiri_check/src/arbitrary.dart';
+import 'package:kiri_check/src/arbitrary/combinator/build.dart';
 import 'package:kiri_check/src/arbitrary/combinator/combine.dart';
 import 'package:kiri_check/src/arbitrary/combinator/deck.dart';
 import 'package:kiri_check/src/arbitrary/combinator/frequency.dart';
@@ -225,6 +226,10 @@ Arbitrary<Set<T>> set<T>(
 
 /// Returns an arbitrary that generates a deck.
 Arbitrary<Deck> deck() => DeckArbitraries.deck();
+
+/// Returns an arbitrary that generates a value using the provided builder.
+Arbitrary<T> build<T>(T Function() builder) =>
+    BuildArbitraries.build<T>(builder);
 
 /// Returns an arbitrary that combines two arbitraries.
 ///

--- a/test/arbitrary/build_test.dart
+++ b/test/arbitrary/build_test.dart
@@ -1,0 +1,31 @@
+import 'dart:math';
+
+import 'package:kiri_check/kiri_check.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('build', () {
+    property('basic', () {
+      const max = 10000;
+      forAll(build(() => Random().nextInt(max)), (n) {
+        expect(n, lessThan(max));
+      });
+    });
+
+    property('shrinking', () {
+      const max = 10000;
+      var current = 0;
+      forAll(
+        build(() => Random().nextInt(max)),
+        (n) {
+          current = n;
+          throw Exception('error');
+        },
+        onFalsify: (n) {
+          expect(n, equals(current));
+        },
+        ignoreFalsify: true,
+      );
+    });
+  });
+}


### PR DESCRIPTION
#20 

The `Deck` argument is not adopted. The reason is that `Deck` does not support shrinking for values generated without using the deck.